### PR TITLE
Allow wiring DSL, macros etc available within Path() macro scope

### DIFF
--- a/lib/trailblazer/activity/dsl/linear.rb
+++ b/lib/trailblazer/activity/dsl/linear.rb
@@ -37,6 +37,21 @@ class Trailblazer::Activity
           sequence
         end
 
+        # Connect last row of the {sequence} to the given step via it's {Id}
+        # Useful when steps needs to be inserted in between {Start} and {connect Id()}.
+        def self.connect(sequence, connect_to:)
+          output, _ = sequence[-1][2][0].(sequence, sequence[-1]) # FIXME: the Forward() proc contains the row's Output, and the only current way to retrieve it is calling the search strategy. It should be Forward#to_h
+
+          searches = [Search.ById(output, connect_to.value)]
+
+          row = sequence[-1]
+          row = row[0..1] + [searches] + [row[3]] # FIXME: not mutating an array is so hard: we only want to replace the "searches" element, index 2
+
+          sequence = sequence[0..-2] + [row]
+
+          sequence
+        end
+
         class IndexError < IndexError
           attr_reader :step_id
 

--- a/lib/trailblazer/activity/dsl/linear/strategy.rb
+++ b/lib/trailblazer/activity/dsl/linear/strategy.rb
@@ -74,7 +74,7 @@ module Trailblazer
             return args[0], options.merge(evaluated_options)
           end
 
-          def Path(options, &block) # syntactically, we can't access the {do ... end} block here.
+          def Path(**options, &block) # syntactically, we can't access the {do ... end} block here.
             BlockProxy.new(options, block)
           end
 


### PR DESCRIPTION
We can't access any wiring DSL (Output, Id etc) or other macros (Nested, Model etc) inside `Path()` helper. It is because we're building the activity directly from `DSL::State`'s sequence without initializing `Strategy` defaults.

This PR changes `sequence` creation from `DSL::State` to it's wrapper `Path` strategy, so that steps inside the block can behave like `Path` OP.

With above behaviour, we can allow connecting outer activities using `{Output() => Id()}`, using custom ends with `{Output() => End()}` at any step in support with `connect_to`.