### PR TITLE
Register PassFast & FailFast ends from their respective DSL options

### DIFF
--- a/lib/trailblazer/activity/fast_track.rb
+++ b/lib/trailblazer/activity/fast_track.rb
@@ -63,6 +63,11 @@ module Trailblazer
         def pass_fast_option((ctx, flow_options), *)
           ctx = merge_connections_for(ctx, ctx, :pass_fast, :success)
 
+          ctx = merge_connections_for(ctx, ctx, :pass_fast, :pass_fast, :pass_fast)
+          ctx = merge_outputs_for(ctx,
+            pass_fast: Activity.Output(Activity::FastTrack::PassFast, :pass_fast),
+          )
+
           return Right, [ctx, flow_options]
         end
 
@@ -75,6 +80,11 @@ module Trailblazer
 
         def fail_fast_option((ctx, flow_options), *)
           ctx = merge_connections_for(ctx, ctx, :fail_fast, :failure)
+
+          ctx = merge_connections_for(ctx, ctx, :fail_fast, :fail_fast, :fail_fast)
+          ctx = merge_outputs_for(ctx,
+            fail_fast: Activity.Output(Activity::FastTrack::FailFast, :fail_fast),
+          )
 
           return Right, [ctx, flow_options]
         end


### PR DESCRIPTION
#### Issue

```ruby
# Below step raises exception "Unrecognized Signal `Trailblazer::Activity::FastTrack::PassFast`"
# even though `pass_fast` option is passed.
step task: ->((ctx, flow_options), **) { return PassFast, [ctx, flow_options] }, pass_fast: true
```

#### Fix
Add `PassFast` or `FailFast`end when it's respective option is given.

It also fixes breaking test reported in https://github.com/trailblazer/trailblazer-macro/commit/7ff85f551ac1ae9b25b333b1f998d5c572ce415f
