### PR TITLE
Fixes in circuit interface normalization when given task is symbol

### DIFF
--- a/lib/trailblazer/activity/dsl/linear/normalizer.rb
+++ b/lib/trailblazer/activity/dsl/linear/normalizer.rb
@@ -57,23 +57,24 @@ module Trailblazer
             options = case ctx[:options]
                       when Hash
                         # Circuit Interface
-                        task = ctx[:options].fetch(:task)
+                        task  = ctx[:options].fetch(:task)
+                        id    = ctx[:options][:id]
 
                         if task.is_a?(Symbol)
-                          # step task: :find
-                          { options: { task: Trailblazer::Option( task ) } }
+                          # step task: :find, id: :load
+                          { **ctx[:options], id: (id || task), task: Trailblazer::Option( task ) }
                         else
                           # step task: Callable, ... (Subprocess, Proc, macros etc)
-                          { task: task }
+                          ctx[:options] # NOOP
                         end
                       else
                         # Step Interface
                         # step :find, ...
                         # step Callable, ... (Method, Proc etc)
-                        { options: { task: ctx[:options], wrap_task: true } }
+                        { task: ctx[:options], wrap_task: true }
                       end
 
-            return Trailblazer::Activity::Right, [ctx.merge(options), flow_options]
+            return Trailblazer::Activity::Right, [ctx.merge(options: options), flow_options]
           end
 
           def wrap_task_with_step_interface((ctx, flow_options), **)

--- a/test/activity_test.rb
+++ b/test/activity_test.rb
@@ -969,7 +969,7 @@ ActivityTest::NestedWithThreeTermini
     ctx.inspect.must_equal     %{{:seq=>[:a, :c, :d, :b]}}
   end
 
-  it "allows {:instance} methods with circuit interface" do
+  it "allows instance methods with circuit interface" do
     implementing = self.implementing
 
     nested_activity = Class.new(Activity::Path) do
@@ -989,6 +989,26 @@ ActivityTest::NestedWithThreeTermini
 
     signal.inspect.must_equal  %{#<Trailblazer::Activity::End semantic=:success>}
     ctx.inspect.must_equal     %{{:seq=>[:a, :c, :d, :b]}}
+  end
+
+  it "assigns {:task} as step's {:id} unless specified" do
+    implementing = self.implementing
+
+    activity = Class.new(Activity::Path) do
+      step task: :a
+      step task: :b, id: :b
+      step task: implementing.method(:c)
+      step task: implementing.method(:d), id: :d
+      step({ task: implementing.method(:f), id: :f }, replace: implementing.method(:c))
+
+      include T.def_tasks(:a, :b)
+    end
+
+    _(Trailblazer::Developer.railway(activity)).must_equal %{[>a,>b,>f,>d]}
+
+    signal, (ctx, _) = activity.([{seq: []}])
+    signal.inspect.must_equal  %{#<Trailblazer::Activity::End semantic=:success>}
+    ctx.inspect.must_equal     %{{:seq=>[:a, :b, :f, :d]}}
   end
 
   it "provides {#to_h}" do


### PR DESCRIPTION
1. Additional {task} options (like {id}) were not getting considered.
2. Assign {task} as an {id} if it's a symbol