### PR TITLE
{:inherit} will only inherit the wirings supported in {child}

### DIFF
--- a/lib/trailblazer/activity/dsl/linear/normalizer.rb
+++ b/lib/trailblazer/activity/dsl/linear/normalizer.rb
@@ -246,11 +246,19 @@ module Trailblazer
             index = Linear::Insert.find_index(sequence, id)
             row   = sequence[index] # from this row we're inheriting options.
 
-            extensions = (row[3][:extensions]||[]) + (ctx[:extensions]||[]) # FIXME: DEFAULTING, FOR FUCK'S SAKE
+            connections = get_inheritable_connections(ctx, row[3][:connections])
+            extensions  = Array(row[3][:extensions]) + Array(ctx[:extensions])
 
-            ctx = ctx.merge(connections: row[3][:connections], extensions: extensions) # "inherit"
+            ctx = ctx.merge(connections: connections, extensions: extensions) # "inherit"
 
             return Trailblazer::Activity::Right, [ctx, flow_options]
+          end
+
+          # return connections from {parent} step which are supported by current step
+          private def get_inheritable_connections(ctx, parent_connections)
+            return parent_connections unless ctx[:outputs]
+
+            parent_connections.slice(*ctx[:outputs].keys)
           end
 
           # TODO: make this extendable!


### PR DESCRIPTION
This would be useful to define a activity template with basic connections and inherit only supported connections in any activity.