### PR TITLE
Set minimum trb-activity version as 0.12.2

### DIFF
--- a/trailblazer-activity-dsl-linear.gemspec
+++ b/trailblazer-activity-dsl-linear.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "trailblazer-activity", ">= 0.12.0", "< 1.0.0"
+  spec.add_dependency "trailblazer-activity", ">= 0.12.2", "< 1.0.0"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "minitest", "~> 5.0"


### PR DESCRIPTION
This is required to avoid conflict with the `Trailblazer::Option`
class extracted from `trailblazer-context`.