### PR TITLE
Add `left` alias for `fail`

### DIFF
--- a/lib/trailblazer/activity/railway.rb
+++ b/lib/trailblazer/activity/railway.rb
@@ -114,6 +114,7 @@ module Trailblazer
         def fail(*args, &block)
           recompile_activity_for(:fail, *args, &block)
         end
+        alias left fail
 
         def pass(*args, &block)
           recompile_activity_for(:pass, *args, &block)

--- a/test/railway_test.rb
+++ b/test/railway_test.rb
@@ -227,6 +227,78 @@ class RailwayTest < Minitest::Spec
   # pass returns false
       assert_call activity, seq: "[:f, :c, :b]", c: Activity::Left
     end
+
+    it "provides {fail}" do
+      implementing = self.implementing
+
+      activity = Class.new(Activity::Railway) do
+        step task: implementing.method(:f), id: :f
+        fail task: implementing.method(:a), id: :a
+        step task: implementing.method(:g), id: :g
+      end
+
+      assert_circuit activity, %{
+#<Start/:default>
+ {Trailblazer::Activity::Right} => #<Method: #<Module:0x>.f>
+#<Method: #<Module:0x>.f>
+ {Trailblazer::Activity::Left} => #<Method: #<Module:0x>.a>
+ {Trailblazer::Activity::Right} => #<Method: #<Module:0x>.g>
+#<Method: #<Module:0x>.a>
+ {Trailblazer::Activity::Left} => #<End/:failure>
+ {Trailblazer::Activity::Right} => #<End/:failure>
+#<Method: #<Module:0x>.g>
+ {Trailblazer::Activity::Left} => #<End/:failure>
+ {Trailblazer::Activity::Right} => #<End/:success>
+#<End/:success>
+
+#<End/:failure>
+}
+
+      # right track
+      assert_call activity, seq: "[:f, :g]"
+
+      # f returns false
+      assert_call activity, f: Activity::Left, seq: "[:f, :a]", terminus: :failure
+
+      # g returns false
+      assert_call activity, g: Activity::Left, seq: "[:f, :g]", terminus: :failure
+    end
+
+    it "provides {failure} alias for {fail}" do
+      implementing = self.implementing
+
+      activity = Class.new(Activity::Railway) do
+        step task: implementing.method(:f), id: :f
+        left task: implementing.method(:a), id: :a
+        step task: implementing.method(:g), id: :g
+      end
+
+      assert_circuit activity, %{
+#<Start/:default>
+ {Trailblazer::Activity::Right} => #<Method: #<Module:0x>.f>
+#<Method: #<Module:0x>.f>
+ {Trailblazer::Activity::Left} => #<Method: #<Module:0x>.a>
+ {Trailblazer::Activity::Right} => #<Method: #<Module:0x>.g>
+#<Method: #<Module:0x>.a>
+ {Trailblazer::Activity::Left} => #<End/:failure>
+ {Trailblazer::Activity::Right} => #<End/:failure>
+#<Method: #<Module:0x>.g>
+ {Trailblazer::Activity::Left} => #<End/:failure>
+ {Trailblazer::Activity::Right} => #<End/:success>
+#<End/:success>
+
+#<End/:failure>
+}
+
+      # right track
+      assert_call activity, seq: "[:f, :g]"
+
+      # f returns false
+      assert_call activity, f: Activity::Left, seq: "[:f, :a]", terminus: :failure
+
+      # g returns false
+      assert_call activity, g: Activity::Left, seq: "[:f, :g]", terminus: :failure
+    end
   end
 
 


### PR DESCRIPTION
This patch adds an alias for the `fail` railway macro. We chose the name `left` because the step will be executed if the activity is on the left track of the railway. Alternative names that we thought about were `flop`, `flaw` or `miss`. 

The motivation behind the alias is to avoid warnings of IDEs (and Rubocop) when using the `fail` method since this method is already defined by Ruby (see https://rubyapi.org/3.2/o/kernel#method-i-fail). Those tools think that code after calling `fail` is unreachable and thus highlight the whole activity definition as unreachable code.