### PR TITLE
Fix undefined method `[]' for nil:NilClass when using TruffleRuby

### DIFF
--- a/lib/trailblazer/activity/dsl/linear/normalizer/output_tuples.rb
+++ b/lib/trailblazer/activity/dsl/linear/normalizer/output_tuples.rb
@@ -18,7 +18,7 @@ module Trailblazer
             # Connector when using Track(:success).
             class Track < Struct.new(:color, :adds, :options)
               def to_a(*)
-                search_strategy = options[:wrap_around] ? :WrapAround : :Forward
+                search_strategy = options&.key?(:wrap_around) ? :WrapAround : :Forward
 
                 return [Linear::Sequence::Search.method(search_strategy), color], adds
               end


### PR DESCRIPTION
Backtrace:

```sh
nicolas@MBP-de-Nicolas:~/PROJECTS/CONCERTO/concerto$ bin/rails s 
setrlimit to increase file descriptor limit failed, errno 22 
/Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/truffleruby/3.2.2.24.0.0.2/gems/trailblazer-activity-dsl-linear-1.2.5/lib/trailblazer/activity/dsl/linear/normalizer/output_tuples.rb:21:in `to_a': undefined method `[]' for nil:NilClass (NoMethodError)
	from /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/truffleruby/3.2.2.24.0.0.2/gems/trailblazer-activity-dsl-linear-1.2.5/lib/trailblazer/activity/dsl/linear/normalizer/output_tuples.rb:132:in `block in compile_wirings'
	from /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/truffleruby/3.2.2.24.0.0.2/gems/trailblazer-activity-dsl-linear-1.2.5/lib/trailblazer/activity/dsl/linear/normalizer/output_tuples.rb:131:in `collect'
	from /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/truffleruby/3.2.2.24.0.0.2/gems/trailblazer-activity-dsl-linear-1.2.5/lib/trailblazer/activity/dsl/linear/normalizer/output_tuples.rb:131:in `compile_wirings'
	from /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/truffleruby/3.2.2.24.0.0.2/bundler/gems/trailblazer-activity-e8589c46f70e/lib/trailblazer/activity/circuit/task_adapter.rb:32:in `call'
	from /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/truffleruby/3.2.2.24.0.0.2/bundler/gems/trailblazer-activity-e8589c46f70e/lib/trailblazer/activity/task_wrap/pipeline.rb:76:in `call'
	from /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/truffleruby/3.2.2.24.0.0.2/bundler/gems/trailblazer-activity-e8589c46f70e/lib/trailblazer/activity/task_wrap/pipeline.rb:16:in `block in call'
	from /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/truffleruby/3.2.2.24.0.0.2/bundler/gems/trailblazer-activity-e8589c46f70e/lib/trailblazer/activity/task_wrap/pipeline.rb:16:in `each'
	from /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/truffleruby/3.2.2.24.0.0.2/bundler/gems/trailblazer-activity-e8589c46f70e/lib/trailblazer/activity/task_wrap/pipeline.rb:16:in `call'
	from /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/truffleruby/3.2.2.24.0.0.2/gems/trailblazer-activity-dsl-linear-1.2.5/lib/trailblazer/activity/dsl/linear/normalizer.rb:25:in `call'
	from /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/truffleruby/3.2.2.24.0.0.2/gems/trailblazer-activity-dsl-linear-1.2.5/lib/trailblazer/activity/dsl/linear/sequence/builder.rb:35:in `invoke_normalizer_for'
	from /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/truffleruby/3.2.2.24.0.0.2/gems/trailblazer-activity-dsl-linear-1.2.5/lib/trailblazer/activity/dsl/linear/sequence/builder.rb:17:in `update_sequence_for'
	from /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/truffleruby/3.2.2.24.0.0.2/gems/trailblazer-activity-dsl-linear-1.2.5/lib/trailblazer/activity/dsl/linear/sequence/builder.rb:10:in `call'
	from /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/truffleruby/3.2.2.24.0.0.2/gems/trailblazer-activity-dsl-linear-1.2.5/lib/trailblazer/activity/dsl/linear/strategy.rb:50:in `apply_step_on_sequence_builder'
	from /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/truffleruby/3.2.2.24.0.0.2/gems/trailblazer-activity-dsl-linear-1.2.5/lib/trailblazer/activity/dsl/linear/strategy.rb:42:in `recompile_activity_for'
	from /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/truffleruby/3.2.2.24.0.0.2/gems/trailblazer-activity-dsl-linear-1.2.5/lib/trailblazer/activity/dsl/linear/strategy.rb:34:in `step'
	from /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/truffleruby/3.2.2.24.0.0.2/bundler/gems/trailblazer-endpoint-0d58b7d09371/lib/trailblazer/endpoint/protocol.rb:25:in `<class:Protocol>'
	from /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/truffleruby/3.2.2.24.0.0.2/bundler/gems/trailblazer-endpoint-0d58b7d09371/lib/trailblazer/endpoint/protocol.rb:17:in `<class:Endpoint>'
	from /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/truffleruby/3.2.2.24.0.0.2/bundler/gems/trailblazer-endpoint-0d58b7d09371/lib/trailblazer/endpoint/protocol.rb:4:in `<module:Trailblazer>'
	from /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/truffleruby/3.2.2.24.0.0.2/bundler/gems/trailblazer-endpoint-0d58b7d09371/lib/trailblazer/endpoint/protocol.rb:3:in `<top (required)>'
	from <internal:core> core/kernel.rb:229:in `gem_original_require'
	from <internal:/Users/nicolas/.asdf/installs/ruby/truffleruby-24.0.1/lib/mri/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/truffleruby/3.2.2.24.0.0.2/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	from /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/truffleruby/3.2.2.24.0.0.2/gems/zeitwerk-2.6.13/lib/zeitwerk/kernel.rb:34:in `require'
	from /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/truffleruby/3.2.2.24.0.0.2/bundler/gems/trailblazer-endpoint-0d58b7d09371/lib/trailblazer/endpoint.rb:159:in `<top (required)>'
	from <internal:core> core/kernel.rb:229:in `gem_original_require'
	from <internal:/Users/nicolas/.asdf/installs/ruby/truffleruby-24.0.1/lib/mri/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/truffleruby/3.2.2.24.0.0.2/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	from /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/truffleruby/3.2.2.24.0.0.2/gems/zeitwerk-2.6.13/lib/zeitwerk/kernel.rb:34:in `require'
	from /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/truffleruby/3.2.2.24.0.0.2/bundler/gems/trailblazer-endpoint-0d58b7d09371/lib/trailblazer-endpoint.rb:1:in `<top (required)>'
	from <internal:core> core/kernel.rb:229:in `gem_original_require'
	from /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/truffleruby/3.2.2.24.0.0.2/gems/zeitwerk-2.6.13/lib/zeitwerk/kernel.rb:34:in `require'
	from /Users/nicolas/.asdf/installs/ruby/truffleruby-24.0.1/lib/mri/bundler/runtime.rb:60:in `block (2 levels) in require'
	from /Users/nicolas/.asdf/installs/ruby/truffleruby-24.0.1/lib/mri/bundler/runtime.rb:55:in `each'
	from /Users/nicolas/.asdf/installs/ruby/truffleruby-24.0.1/lib/mri/bundler/runtime.rb:55:in `block in require'
	from /Users/nicolas/.asdf/installs/ruby/truffleruby-24.0.1/lib/mri/bundler/runtime.rb:44:in `each'
	from /Users/nicolas/.asdf/installs/ruby/truffleruby-24.0.1/lib/mri/bundler/runtime.rb:44:in `require'
	from /Users/nicolas/.asdf/installs/ruby/truffleruby-24.0.1/lib/mri/bundler.rb:197:in `require'
	from /Users/nicolas/PROJECTS/CONCERTO/concerto/config/application.rb:31:in `<top (required)>'
	from <internal:core> core/kernel.rb:229:in `gem_original_require'
	from <internal:/Users/nicolas/.asdf/installs/ruby/truffleruby-24.0.1/lib/mri/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/truffleruby/3.2.2.24.0.0.2/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	from /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/truffleruby/3.2.2.24.0.0.2/gems/railties-7.1.3.2/lib/rails/commands/server/server_command.rb:139:in `block in perform'
	from <internal:core> core/kernel.rb:512:in `tap'
	from /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/truffleruby/3.2.2.24.0.0.2/gems/railties-7.1.3.2/lib/rails/commands/server/server_command.rb:136:in `perform'
	from /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/truffleruby/3.2.2.24.0.0.2/gems/thor-1.3.1/lib/thor/command.rb:28:in `run'
	from /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/truffleruby/3.2.2.24.0.0.2/gems/thor-1.3.1/lib/thor/invocation.rb:127:in `invoke_command'
	from /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/truffleruby/3.2.2.24.0.0.2/gems/railties-7.1.3.2/lib/rails/command/base.rb:178:in `invoke_command'
	from /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/truffleruby/3.2.2.24.0.0.2/gems/thor-1.3.1/lib/thor.rb:527:in `dispatch'
	from /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/truffleruby/3.2.2.24.0.0.2/gems/railties-7.1.3.2/lib/rails/command/base.rb:73:in `perform'
	from /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/truffleruby/3.2.2.24.0.0.2/gems/railties-7.1.3.2/lib/rails/command.rb:71:in `block in invoke'
	from /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/truffleruby/3.2.2.24.0.0.2/gems/railties-7.1.3.2/lib/rails/command.rb:149:in `with_argv'
	from /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/truffleruby/3.2.2.24.0.0.2/gems/railties-7.1.3.2/lib/rails/command.rb:69:in `invoke'
	from /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/truffleruby/3.2.2.24.0.0.2/gems/railties-7.1.3.2/lib/rails/commands.rb:18:in `<top (required)>'
	from <internal:core> core/kernel.rb:229:in `gem_original_require'
	from <internal:/Users/nicolas/.asdf/installs/ruby/truffleruby-24.0.1/lib/mri/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/truffleruby/3.2.2.24.0.0.2/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	from bin/rails:4:in `<main>'
```